### PR TITLE
Fix module load command of HDF5

### DIFF
--- a/compute/taurus/sw.md
+++ b/compute/taurus/sw.md
@@ -92,7 +92,7 @@ $ python -m ipykernel install --user --name my-custom-kernel --display-name="my 
 At this point, you are free to `module load foo` where `foo` can be any package that you find:
 
 ``` shell
-$ module load HDF5/1.10.5
+$ module load HDF5/1.10.5-gompic-2019a
 $ pip install h5py
 ```
 


### PR DESCRIPTION
The given module is not available on the `ml` node. If you do not specify a specific version, `1.10.5-HDF5/gompic-2019a` gets loaded.

I can either remove the version string entirely or set the version that gets loaded by default.

This is the list of available versions:
```
HDF5/1.10.1-foss-2018a
HDF5/1.10.1-gsolf-2018a
HDF5/1.10.1-intel-2018a
HDF5/1.10.1-iomkl-2018a
HDF5/1.10.2-foss-2018b
HDF5/1.10.2-fosscuda-2018b
HDF5/1.10.2-intel-2018b
HDF5/1.10.5-foss-2019a
HDF5/1.10.5-gompi-2019a
HDF5/1.10.5-gompic-2019a
HDF5/1.10.5-iimpi-2019a
```